### PR TITLE
Sjh

### DIFF
--- a/ai-basic/lab02-vectordb/basic_chroma.py
+++ b/ai-basic/lab02-vectordb/basic_chroma.py
@@ -307,7 +307,11 @@ def demonstrate_persistence():
     
     # 메모리 클라이언트 생성
     memory_client = setup_chroma_client(use_persistence=False)
-    memory_collection = memory_client.create_collection("temp_collection")
+    openai_ef = ChromaUtils.create_openai_embedding_function()
+    memory_collection = memory_client.create_collection(
+        "temp_collection", 
+        embedding_function=openai_ef
+    )
     
     memory_collection.add(
         documents=["임시 문서입니다."],

--- a/ai-basic/lab02-vectordb/document_indexing.py
+++ b/ai-basic/lab02-vectordb/document_indexing.py
@@ -47,10 +47,15 @@ class DocumentIndexer:
             except Exception as e:
                 print(f"컬렉션 삭제 실패: {e}")
         
+        # SSL 우회 임베딩 함수 추가
+        from shared.utils import ChromaUtils
+        openai_ef = ChromaUtils.create_openai_embedding_function()
+        
         # 컬렉션 생성 또는 가져오기
         try:
             self.collection = self.client.create_collection(
                 name=self.collection_name,
+                embedding_function=openai_ef,
                 metadata={"description": "대용량 문서 인덱싱용 컬렉션"}
             )
             print(f"새 컬렉션 '{self.collection_name}' 생성됨")

--- a/ai-basic/lab02-vectordb/metadata_filtering.py
+++ b/ai-basic/lab02-vectordb/metadata_filtering.py
@@ -9,7 +9,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import chromadb
 from shared.config import validate_api_keys, CHROMA_PERSIST_DIRECTORY
-from shared.utils import EmbeddingUtils
+from shared.utils import EmbeddingUtils, ChromaUtils  
 import time
 import random
 from typing import List, Dict, Any, Optional
@@ -29,6 +29,9 @@ class AdvancedSearchEngine:
         print("고급 검색 엔진 초기화")
         print("=" * 40)
         
+        # OpenAI 임베딩 함수 설정 추가
+        openai_ef = ChromaUtils.create_openai_embedding_function()
+
         if reset:
             try:
                 self.client.delete_collection(self.collection_name)
@@ -39,13 +42,17 @@ class AdvancedSearchEngine:
         try:
             self.collection = self.client.create_collection(
                 name=self.collection_name,
+                embedding_function=openai_ef,
                 metadata={"description": "고급 메타데이터 검색용 컬렉션"}
             )
             print(f"새 컬렉션 '{self.collection_name}' 생성됨")
         except Exception:
-            self.collection = self.client.get_collection(self.collection_name)
+            self.collection = self.client.get_collection(
+                self.collection_name,
+                embedding_function=openai_ef
+            )
             print(f"기존 컬렉션 '{self.collection_name}' 로드됨")
-        
+
         print(f"컬렉션 문서 수: {self.collection.count()}")
     
     def add_documents(self, documents: List[Dict[str, Any]]):

--- a/ai-basic/lab03-rag/advanced_retrieval.py
+++ b/ai-basic/lab03-rag/advanced_retrieval.py
@@ -10,7 +10,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import chromadb
 from chromadb.utils import embedding_functions
 from shared.config import validate_api_keys, CHROMA_PERSIST_DIRECTORY, OPENAI_API_KEY, CHAT_MODEL
-from shared.utils import EmbeddingUtils, ChatUtils
+from shared.utils import EmbeddingUtils, ChatUtils, ChromaUtils
 import numpy as np
 import time
 import re

--- a/ai-basic/lab03-rag/advanced_retrieval_langchain.py
+++ b/ai-basic/lab03-rag/advanced_retrieval_langchain.py
@@ -11,6 +11,7 @@ from shared.config import validate_api_keys, CHROMA_PERSIST_DIRECTORY, OPENAI_AP
 import time
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
+import httpx
 
 # LangChain imports
 from langchain_openai import OpenAIEmbeddings, ChatOpenAI
@@ -28,6 +29,10 @@ from langchain.retrievers.document_compressors import DocumentCompressorPipeline
 from langchain.retrievers import ContextualCompressionRetriever
 from langchain.retrievers.document_compressors import EmbeddingsFilter, LLMChainExtractor
 from langchain_community.document_transformers import EmbeddingsRedundantFilter
+
+# SSL 검증 비활성화 HTTP 클라이언트
+no_ssl_httpx = httpx.Client(verify=False)
+
 
 @dataclass
 class AdvancedSearchResult:
@@ -51,13 +56,15 @@ class LangChainAdvancedRetriever:
         # 기본 컴포넌트 초기화
         self.embeddings = OpenAIEmbeddings(
             openai_api_key=OPENAI_API_KEY,
-            model="text-embedding-ada-002"
+            model="text-embedding-ada-002",
+            http_client=no_ssl_httpx
         )
         
         self.llm = ChatOpenAI(
             openai_api_key=OPENAI_API_KEY,
             model=CHAT_MODEL,
-            temperature=0.1
+            temperature=0.1,
+            http_client=no_ssl_httpx
         )
         
         self.text_splitter = RecursiveCharacterTextSplitter(

--- a/ai-basic/lab03-rag/basic_rag.py
+++ b/ai-basic/lab03-rag/basic_rag.py
@@ -10,7 +10,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import chromadb
 from chromadb.utils import embedding_functions
 from shared.config import validate_api_keys, CHROMA_PERSIST_DIRECTORY, OPENAI_API_KEY, CHAT_MODEL, TEMPERATURE
-from shared.utils import EmbeddingUtils, ChatUtils
+from shared.utils import EmbeddingUtils, ChatUtils, ChromaUtils
 import time
 import json
 from typing import List, Dict, Any, Optional, Tuple

--- a/ai-basic/lab03-rag/basic_rag_langchain.py
+++ b/ai-basic/lab03-rag/basic_rag_langchain.py
@@ -11,6 +11,7 @@ from shared.config import validate_api_keys, CHROMA_PERSIST_DIRECTORY, OPENAI_AP
 import time
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
+import httpx
 
 # LangChain imports
 from langchain_openai import OpenAIEmbeddings, ChatOpenAI
@@ -20,6 +21,10 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.runnables import RunnablePassthrough, RunnableParallel
 from langchain.schema import Document
+
+# SSL 검증 비활성화 HTTP 클라이언트
+no_ssl_httpx = httpx.Client(verify=False)
+
 
 @dataclass
 class LangChainRAGResponse:
@@ -43,13 +48,15 @@ class LangChainRAGSystem:
         # LangChain 컴포넌트 초기화
         self.embeddings = OpenAIEmbeddings(
             openai_api_key=OPENAI_API_KEY,
-            model="text-embedding-ada-002"
+            model="text-embedding-ada-002",
+            http_client=no_ssl_httpx
         )
         
         self.llm = ChatOpenAI(
             openai_api_key=OPENAI_API_KEY,
             model=CHAT_MODEL,
-            temperature=0.1
+            temperature=0.1,
+            http_client=no_ssl_httpx
         )
         
         self.text_splitter = RecursiveCharacterTextSplitter(

--- a/ai-basic/lab04-intelligent-chatbot/agents/intent_classifier.py
+++ b/ai-basic/lab04-intelligent-chatbot/agents/intent_classifier.py
@@ -8,7 +8,7 @@ import os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 
 from shared.config import validate_api_keys, OPENAI_API_KEY, CHAT_MODEL
-from shared.utils import ChatUtils
+from shared.utils import ChatUtils, ChromaUtils
 import json
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple

--- a/ai-basic/lab04-intelligent-chatbot/main_chatbot.py
+++ b/ai-basic/lab04-intelligent-chatbot/main_chatbot.py
@@ -8,6 +8,7 @@ import os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from shared.config import validate_api_keys
+from shared.utils import ChromaUtils
 from agents.intent_classifier import IntentClassifier
 from agents.weather_agent import WeatherAgent
 from agents.calendar_agent import CalendarAgent

--- a/ai-basic/lab04-intelligent-chatbot/rag_system/knowledge_base.py
+++ b/ai-basic/lab04-intelligent-chatbot/rag_system/knowledge_base.py
@@ -14,7 +14,7 @@ import uuid
 from datetime import datetime
 from typing import Dict, List, Optional, Any, Tuple
 from shared.config import OPENAI_API_KEY, CHAT_MODEL
-from shared.utils import EmbeddingUtils
+from shared.utils import EmbeddingUtils, ChromaUtils
 
 class KnowledgeBase:
     """RAG 지식베이스 관리자"""

--- a/ai-basic/shared/utils.py
+++ b/ai-basic/shared/utils.py
@@ -25,11 +25,26 @@ except ImportError:
 # SSL 검증 비활성화 설정 (사내망 환경용)
 os.environ['CURL_CA_BUNDLE'] = ''
 os.environ['REQUESTS_CA_BUNDLE'] = ''
+os.environ['SSL_VERIFY'] = 'false'
+os.environ['PYTHONHTTPSVERIFY'] = '0'
+os.environ['CHROMA_ANALYTICS'] = 'false'  # ChromaDB 텔레메트리 비활성화
+# posthog.com 전송 실패 로그 안보이기 위한 세팅
+os.environ['ANONYMIZED_TELEMETRY'] = 'false'
+os.environ['CHROMA_TELEMETRY_DISABLED'] = 'true'
+
+# urllib3 경고 비활성화
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+urllib3.disable_warnings()
 
 # 로깅 설정
 logging.basicConfig(level=getattr(logging, LOG_LEVEL))
 logger = logging.getLogger(__name__)
+
+# 특정 로거들의 레벨을 높여서 경고 숨기기
+logging.getLogger('urllib3.connectionpool').setLevel(logging.ERROR)
+logging.getLogger('backoff').setLevel(logging.ERROR)
+logging.getLogger('chromadb.telemetry.product.posthog').setLevel(logging.ERROR)
+logging.getLogger('httpx').setLevel(logging.WARNING)
 
 # SSL 검증 비활성화 HTTP 클라이언트 생성
 no_ssl_httpx = httpx.Client(verify=False)
@@ -169,17 +184,51 @@ class ChatUtils:
 
 class ChromaUtils:
     """ChromaDB 관련 유틸리티 클래스"""
-    
+
     @staticmethod
-    def create_openai_embedding_function(api_key: str = OPENAI_API_KEY, 
+    def create_openai_embedding_function(api_key: str = OPENAI_API_KEY,
                                        model_name: str = "text-embedding-ada-002"):
         """SSL 검증 비활성화된 OpenAI 임베딩 함수 생성"""
-        http_client = httpx.Client(verify=False)
-        return embedding_functions.OpenAIEmbeddingFunction(
-            api_key=api_key,
-            model_name=model_name,
-            http_client=http_client
-        )
+        try:
+            # 사내망 환경을 위한 추가 설정
+            import openai
+            
+            # OpenAI 클라이언트 직접 설정으로 우회
+            class CustomOpenAIEmbeddingFunction:
+                def __init__(self, api_key, model_name):
+                    self.api_key = api_key
+                    self.model_name = model_name
+                    self.client = OpenAI(api_key=api_key, http_client=no_ssl_httpx)
+                
+                def name(self):
+                    return f"openai-{self.model_name}"
+
+                def __call__(self, input):
+                    if isinstance(input, str):
+                        input = [input]
+                    
+                    response = self.client.embeddings.create(
+                        input=input,
+                        model=self.model_name
+                    )
+                    return [data.embedding for data in response.data]
+                
+                def embed_query(self, input):
+                    """단일 쿼리 임베딩 - ChromaDB 1.1.0에서 필요"""
+                    if isinstance(input, list):
+                        return self.__call__(input)
+                    else:
+                        return self.__call__([input])[0]
+            
+            return CustomOpenAIEmbeddingFunction(api_key, model_name)
+            
+        except Exception as e:
+            logger.warning(f"Custom embedding function 생성 실패, 기본값 사용: {e}")
+            # 기본 ChromaDB 임베딩 함수 사용
+            return embedding_functions.OpenAIEmbeddingFunction(
+                api_key=api_key,
+                model_name=model_name
+            )
 
 class PerformanceUtils:
     """성능 측정 유틸리티 클래스"""


### PR DESCRIPTION
lab02~lab04까지 수정사항이에요~(lab01의 경우 금요일에 했었구 대리님이 merge하심) 

이번에 
utils.py쪽에 warning오류들 즉
텔레메트리 오류: posthog.com 전송 실패 관련 로그들이 너무 자주 발생하고 많이떠서(사내망이라 어쩔 수 없는..) 
관련해서 설정들이 많이 추가됐어요

특이사항 : 
1. performance_comparison.py 쪽에 
# ChromaDB 텔레메트리 비활성화 (반복적인 컬렉션 생성으로 인한 텔레메트리 재시도 방지)
os.environ['CHROMA_ANALYTICS'] = 'false'
os.environ['ANONYMIZED_TELEMETRY'] = 'false'  
os.environ['CHROMA_TELEMETRY_DISABLED'] = 'true'

<<< 이거를 utils.py랑 중복으로 썼는데 이유가 
여러 컬렉션을 계속 생성 → ChromaUtils.create_openai_embedding_function() 반복 호출
그때마다 chromadb 텔레메트리 체크  라고 하더라구요..? 그래서 어쩔수없이 이렇게 했는데 이거 해결방법 있나염? 


2. performance_comparison.py 에서 
batch_sizes = [10, 25, 50, 100, 200] # 500 제거 (kt 보안 정책에서 대용량 업로드 감지당함)